### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ ossprojects
 
 Systers is committed to helping other women in computing/technology to enhance their coding skills and improve overall development process. We have several open source projects to help with effort.
 
-Please visit our 2017 <a href="https://github.com/systers/ossprojects/wiki/GSoC-2017">Google Summer of Code page</a> for a list of our open source projects.
+Please visit our 2018 <a href="https://github.com/systers/systers.github.io/wiki/GSoC-2018">Google Summer of Code page</a> for a list of our open source projects.


### PR DESCRIPTION
### Description
"Please visit our 2017 Google Summer of Code page for a list of our open source projects" changed with "Please visit our 2018 Google Summer of Code page for a list of our open source projects."
The link in the text "Google Summer of Code" now directs to the GSOC 2018 page of systers.
Fixes [#24](https://github.com/systers/ossprojects/issues/24)

### Type of Change:
Documentation
### How Has This Been Tested?
Simply went through the link updated in the README.md and it now successfully links to the ideas page of Systers GSOC 2018.

Checklist:
 - [x] My PR follows the style guidelines of this project
 - [x] I have performed a self-review of my own code or materials